### PR TITLE
feat: Implement OTP Code Entry Screen UI

### DIFF
--- a/app/(auth)/verify.tsx
+++ b/app/(auth)/verify.tsx
@@ -1,13 +1,29 @@
+import Button from '@src/components/button';
+import OtpInput from '@src/components/otp-input';
 import Screen from '@src/components/screen';
+import useCountdownTimer from '@src/hooks/countdown-timer';
 import React from 'react';
-import { H3 } from 'tamagui';
+import { H2, Paragraph } from 'tamagui';
 
 function VerifyScreen() {
+    const { secondsToDate } = useCountdownTimer();
+
     return (
         <Screen
+            alignItems="center"
             justifyContent="center"
-            alignItems="center">
-            <H3>Verify Screen</H3>
+            space>
+            <H2 fontWeight="bold">{secondsToDate}</H2>
+            <Paragraph
+                fontSize="$6"
+                color="$textPrimary70"
+                lineHeight="$3">
+                Type the verification code we’ve sent you
+            </Paragraph>
+
+            <OtpInput length={4} />
+
+            <Button isText>Send again</Button>
         </Screen>
     );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -2,7 +2,7 @@ import { Redirect } from 'expo-router';
 import React from 'react';
 
 function RootScreen() {
-    return <Redirect href="/signup" />;
+    return <Redirect href="/verify" />;
 }
 
 export default RootScreen;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@shopify/flash-list": "1.4.3",
     "@tamagui/config": "^1.76.0",
     "expo": "~49.0.15",
+    "expo-clipboard": "~4.3.1",
     "expo-dev-client": "~2.4.11",
     "expo-font": "~11.4.0",
     "expo-linking": "~5.0.2",

--- a/src/components/otp-input.tsx
+++ b/src/components/otp-input.tsx
@@ -1,8 +1,9 @@
+import useOtpClipboard from '@src/hooks/otp-clipboard';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { NativeSyntheticEvent, TextInput, TextInputKeyPressEventData } from 'react-native';
 import { Input, XStack, styled } from 'tamagui';
 
-interface IOtpInputs {
+interface IOtpInputProps {
     length?: number;
 }
 
@@ -27,16 +28,25 @@ const OtpTextField = styled(Input, {
     },
 });
 
-function OtpInput(props: IOtpInputs) {
+function OtpInput(props: IOtpInputProps) {
     const [otp, setOtp] = useState<string[]>(new Array(props?.length ?? 4).fill(''));
     const inputs = useRef<TextInput[]>([]);
     const currentInputIndex = useRef<number>();
 
+    useOtpClipboard({
+        pinCount: 4,
+        updateOtpState: otpValue => setOtp(otpValue),
+    });
+
     useEffect(() => {
         if (otp[otp.length - 1] !== '') {
-            alert("You're verified successfully.");
+            verifySuccesfull();
         }
     }, [otp]);
+
+    const verifySuccesfull = useCallback(() => {
+        alert("You're verified succesfuly.");
+    }, []);
 
     const handleOtpChange = (value: string, index: number) => {
         const newOtp = [...otp];

--- a/src/components/otp-input.tsx
+++ b/src/components/otp-input.tsx
@@ -34,7 +34,7 @@ function OtpInput(props: IOtpInputProps) {
     const currentInputIndex = useRef<number>();
 
     useOtpClipboard({
-        pinCount: 4,
+        pinCount: props?.length ?? 4,
         updateOtpState: otpValue => setOtp(otpValue),
     });
 

--- a/src/components/otp-input.tsx
+++ b/src/components/otp-input.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { NativeSyntheticEvent, TextInput, TextInputKeyPressEventData } from 'react-native';
+import { Input, XStack, styled } from 'tamagui';
+
+interface IOtpInputs {
+    length?: number;
+}
+
+const OtpTextField = styled(Input, {
+    width: 70,
+    height: 70,
+    textAlign: 'center',
+    textAlignVertical: 'center',
+    fontSize: '$9',
+
+    variants: {
+        isFilled: {
+            true: {
+                bg: '$primary',
+                color: 'white',
+            },
+            false: {
+                borderColor: '$border',
+                placeholderTextColor: '$border',
+            },
+        },
+    },
+});
+
+function OtpInput(props: IOtpInputs) {
+    const [otp, setOtp] = useState<string[]>(new Array(props?.length ?? 4).fill(''));
+    const inputs = useRef<TextInput[]>([]);
+    const currentInputIndex = useRef<number>();
+
+    useEffect(() => {
+        if (otp[otp.length - 1] !== '') {
+            alert("You're verified successfully.");
+        }
+    }, [otp]);
+
+    const handleOtpChange = (value: string, index: number) => {
+        const newOtp = [...otp];
+        newOtp[index] = value;
+        setOtp(newOtp);
+
+        // Move focus to the next box if the current one has a value
+        if (value && index < newOtp.length - 1) {
+            currentInputIndex.current = index + 1;
+            focusNextInput(index + 1);
+        }
+
+        // Move focus to the previous box if the current one has no value
+        if (!value && index < newOtp.length + 1) {
+            currentInputIndex.current = index - 1;
+            focusPrevInput(index - 1);
+        }
+    };
+
+    const focusPrevInput = useCallback(
+        (index?: number) => {
+            const prevIndex = currentInputIndex.current! - 1;
+            const prevInput = inputs.current[index ?? prevIndex];
+
+            if (prevInput) {
+                currentInputIndex.current = prevIndex;
+            }
+
+            prevInput?.focus();
+        },
+        [currentInputIndex],
+    );
+
+    const focusNextInput = useCallback(
+        (index?: number) => {
+            const nextIndex = currentInputIndex.current! + 1;
+            const nextInput = inputs.current[index ?? nextIndex];
+            nextInput?.focus();
+        },
+        [currentInputIndex],
+    );
+
+    const onKeyPress = useCallback(
+        (e: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+            if (e.nativeEvent.key === 'Backspace') {
+                if (otp[currentInputIndex.current!] === '') {
+                    focusPrevInput();
+                }
+            }
+        },
+        [otp],
+    );
+
+    return (
+        <XStack space>
+            {otp.map((digit, index) => (
+                <OtpTextField
+                    key={index}
+                    maxLength={1}
+                    isFilled={otp[index] !== ''}
+                    keyboardType="numeric"
+                    onChangeText={value => handleOtpChange(value, index)}
+                    value={digit}
+                    autoComplete="sms-otp"
+                    textContentType="oneTimeCode"
+                    placeholder="0"
+                    onKeyPress={onKeyPress}
+                    caretHidden
+                    ref={input => {
+                        if (input) {
+                            inputs.current[index] = input;
+                        }
+                    }}
+                />
+            ))}
+        </XStack>
+    );
+}
+
+export default OtpInput;

--- a/src/hooks/countdown-timer.ts
+++ b/src/hooks/countdown-timer.ts
@@ -1,0 +1,39 @@
+import { useEffect, useMemo, useState } from 'react';
+
+export enum CountdownTimerSeconds {
+    FiveMinutes = 300,
+    TenMinutes = 600,
+}
+
+export interface ICountdownProps {
+    seconds?: CountdownTimerSeconds;
+}
+
+function useCountdownTimer(props?: ICountdownProps) {
+    const [seconds, setSeconds] = useState<CountdownTimerSeconds>(
+        props?.seconds ?? CountdownTimerSeconds.FiveMinutes,
+    );
+
+    const secondsToDate = useMemo(() => {
+        return new Intl.DateTimeFormat('en-US', {
+            minute: '2-digit',
+            second: '2-digit',
+        }).format(new Date(seconds * 1000));
+    }, [seconds]);
+
+    useEffect(() => {
+        const timer = seconds > 0 && setInterval(() => setSeconds(seconds - 1), 1000);
+
+        return () => {
+            if (timer) {
+                clearInterval(timer);
+            }
+        };
+    }, [seconds]);
+
+    return {
+        secondsToDate,
+    };
+}
+
+export default useCountdownTimer;

--- a/src/hooks/countdown-timer.ts
+++ b/src/hooks/countdown-timer.ts
@@ -13,7 +13,6 @@ function useCountdownTimer(props?: ICountdownProps) {
     const [seconds, setSeconds] = useState<CountdownTimerSeconds>(
         props?.seconds ?? CountdownTimerSeconds.FiveMinutes,
     );
-
     const secondsToDate = useMemo(() => {
         return new Intl.DateTimeFormat('en-US', {
             minute: '2-digit',

--- a/src/hooks/otp-clipboard.ts
+++ b/src/hooks/otp-clipboard.ts
@@ -1,0 +1,33 @@
+import * as Clipboard from 'expo-clipboard';
+import { useEffect } from 'react';
+
+interface IProps {
+    pinCount: number;
+    updateOtpState: (otpValue: string[]) => void;
+}
+
+function useOtpClipboard(props: IProps) {
+    useEffect(() => {
+        const clipboardListener = Clipboard.addClipboardListener(async e => {
+            if (!e.contentTypes.includes(Clipboard.ContentType.PLAIN_TEXT)) {
+                return;
+            }
+
+            const regexp = new RegExp(`^\\d{${props.pinCount}}$`);
+
+            const content = await Clipboard.getStringAsync();
+
+            const ifIsPin = regexp.test(content);
+
+            if (ifIsPin) {
+                props.updateOtpState(content.split(''));
+            }
+        });
+
+        return () => {
+            clipboardListener.remove();
+        };
+    }, []);
+}
+
+export default useOtpClipboard;

--- a/src/tamagui/fonts.ts
+++ b/src/tamagui/fonts.ts
@@ -23,6 +23,7 @@ const genericFontSizes = {
 const genericLineHeights = {
     1: 21,
     2: 24,
+    3: 27,
     true: 21,
 };
 const headingLineHeights = {

--- a/src/tamagui/tokens.ts
+++ b/src/tamagui/tokens.ts
@@ -10,6 +10,7 @@ const customToken = createTokens({
         textPrimary40: 'rgba(0,0,0,.4)',
         textSecondary: '#323755',
         primary: '#E94057',
+        border: '#E8E6EA',
     },
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5662,6 +5662,11 @@ expo-asset@~8.10.1:
     path-browserify "^1.0.0"
     url-parse "^1.5.9"
 
+expo-clipboard@~4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/expo-clipboard/-/expo-clipboard-4.3.1.tgz#ce6ed35ae31c7fc1aeadb005b8eb9b39a8bb9b40"
+  integrity sha512-WIsjvAsr2+/NZRa84mKxjui1EdPpdKbQIC2LN/KMBNuT7g4GQYL3oo9WO9G/C7doKQ7f7pnfdvO3N6fUnoRoJw==
+
 expo-constants@~14.4.2:
   version "14.4.2"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-14.4.2.tgz#cac5e8b524069545739b8d8595ce96cc5be6578c"


### PR DESCRIPTION
You will need to download latest dev client to be able to run

Latest build: [Download here](https://expo.dev/artifacts/eas/vz3L7tGj5QhyYegqnmjUBi.apk)

![untitled](https://github.com/dglalperen/project-101-heart-connect/assets/17166855/bafba20e-a1f8-4492-8b4d-11a82d2e011e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced OTP (One-Time Password) input field with automatic clipboard detection.
	- Added countdown timer display for OTP verification.
	- Implemented "Send again" button for OTP.
- **Refactor**
	- Changed redirection target from "/signup" to "/verify".
- **Style**
	- Updated font line-heights and added new color definition for borders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->